### PR TITLE
Usings outside of namespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -164,7 +164,7 @@ csharp_prefer_braces = true:warning
 csharp_prefer_simple_using_statement = true:suggestion
 dotnet_diagnostic.IDE0063.severity = suggestion
 # 'using' directive preferences
-csharp_using_directive_placement = inside_namespace:warning
+csharp_using_directive_placement = outside_namespace:warning
 # Modifier preferences
 csharp_prefer_static_local_function = true:warning
 # Undocumented


### PR DESCRIPTION
Det er mere eller mindre en industri standard at have sine usings uden for namespace, jeg er stor fortaler for at følge industrien (tried and proven). De scenarier hvor det giver mening at have usings inden for namespace der kan man så supresse den warning det giver, jeg tror dog at det vil være meget få tilfælde hvor det vil give mening, og endnu mindre med file-wide namespaces i .net 6 samt global usings